### PR TITLE
Update deprecated reagent/render dependency

### DIFF
--- a/resources/core/cljs/client.cljs
+++ b/resources/core/cljs/client.cljs
@@ -7,7 +7,7 @@
   (:require [ajax.core :as ajax]
             [re-frame.core :as rf]
             [day8.re-frame.http-fx]
-            [reagent.core :as reagent]
+            [reagent.dom :as rd]
             [<<namespace>>.client.home :as home]<<#hydrogen-session?>>
             [<<namespace>>.client.landing :as landing]<</hydrogen-session?>>
             [<<namespace>>.client.routes :as routes]<<#hydrogen-session-keycloak?>>
@@ -76,7 +76,7 @@
 
 (defn mount-root []
   (rf/clear-subscription-cache!)
-  (reagent/render [main] (.getElementById js/document "app")))
+  (rd/render [main] (.getElementById js/document "app")))
 
 (defn ^:export init []
   (dev-setup)


### PR DESCRIPTION
[Re #24] [Fix #24]

Update dependency to use `reagent.dom` namespace instead of `reagent.core` for calling the `render` function.